### PR TITLE
Bump GitHub Actions checkout and setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` and `actions/setup-node` from v4 to v5 in both the CI and Publish workflows. This clears the Node.js 20 runtime deprecation warning GitHub now emits (v4 actions were being force-run on Node 24 by the runners). `codecov-action` was already on v5.

Follow-up to #16, which surfaced the warning.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/CD

## Testing

- [x] CI runs green on the PR with the v5 actions (Node 20 & 22)
- [x] Deprecation annotation no longer emitted

## Related Issues

N/A