### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.2] - 2026-06-22
+
+### Fixed
+
+- `--version` now reports the actual package version (was hardcoded to `1.0.0`); the version is read dynamically from `package.json` so it can no longer drift
+- Resolved latent type errors in `safeForEach` and severity parsing (behavior-preserving)
+
+### Changed
+
+- Updated development dependencies and cleared all security advisories (`npm audit` reports 0 vulnerabilities)
+- Upgraded to ESLint 10 and `@types/node` 26
+- Bumped GitHub Actions `checkout` and `setup-node` to v5
+
+### Added
+
+- `typecheck` script (`tsc --noEmit`) wired into CI to catch type errors that the esbuild-based build and tests previously skipped
+
 ## [1.0.1] - 2026-01-30
 
 ### Added
@@ -42,5 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Provenance attestation on published packages
 - GitHub issue and PR templates
 
+[1.0.2]: https://github.com/ryancalacsan/print-check-cli/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/ryancalacsan/print-check-cli/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/ryancalacsan/print-check-cli/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-check-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "bin": {
     "print-check": "./dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,10 @@ import { Command } from "commander";
 import { z } from "zod";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
 import {
   checkBleedTrim,
   checkFonts,
@@ -91,7 +95,7 @@ const program = new Command();
 program
   .name("print-check")
   .description("Validate print-ready PDF files")
-  .version("1.0.0")
+  .version(version)
   .argument("<files...>", "PDF file(s) to check")
   .option("--min-dpi <number>", "Minimum acceptable DPI")
   .option("--color-space <mode>", "Expected color space: cmyk | any")


### PR DESCRIPTION
## Summary

Patch release. The headline fix: `print-check --version` reported `1.0.0` regardless of the actual package version because it was hardcoded in `src/index.ts`. It now reads `version` from `package.json` via `createRequire`, so it can never drift again.

Also rolls up the maintenance merged since 1.0.1 (dependency/security refresh, ESLint 10, typecheck guard, GitHub Actions v5) into a tagged release and documents it in the changelog.

- Bumps `package.json` to `1.0.2`
- Adds a `[1.0.2]` CHANGELOG entry + compare link

Merging this, then tagging `v1.0.2` triggers the OIDC trusted-publish workflow to npm.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/CD

## Testing

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] `npm run typecheck` / `lint` / `format:check` pass
- [x] Verified `--version` reports `1.0.2` in both built (`node dist/index.js`) and dev (`tsx`) modes
- [x] Smoke-tested against a sample PDF

## Related Issues

N/A